### PR TITLE
[BUG] Fix formatting on hashtags, mentions

### DIFF
--- a/modules/Preprocessing.py
+++ b/modules/Preprocessing.py
@@ -121,7 +121,7 @@ def get_tweet_data(tweets: List[Dict[str, str]]):
                     # add to local mentions
                     tweet['mentions'].append(clean_word)
                     # add to overall mentions
-                    mention_stats[clean_word.lower()] = mention_stats.get(clean_word.lower(), 0) + 1
+                    mention_stats[clean_word] = mention_stats.get(clean_word, 0) + 1
                     # remove mention
                     tweet_text = tweet_text.replace(word, '')
         # handle dates

--- a/modules/Preprocessing.py
+++ b/modules/Preprocessing.py
@@ -108,11 +108,11 @@ def get_tweet_data(tweets: List[Dict[str, str]]):
             for word in tweet_text.split(' '):
                 if word.startswith('#'):
                     # clean hashtag
-                    clean_word = re.sub(_REGEX_CHAR_MATCHER_TWEETS, "", word)
+                    clean_word = re.sub(_REGEX_CHAR_MATCHER_TWEETS, "", word).lower()
                     # add to local hashtags
                     tweet['hashtags'].append(clean_word)
                     # add to overall hashtags
-                    hashtag_stats[clean_word.lower()] = hashtag_stats.get(clean_word.lower(), 0) + 1
+                    hashtag_stats[clean_word] = hashtag_stats.get(clean_word, 0) + 1
                     # remove hashtag
                     tweet_text = tweet_text.replace(word, '')
                 if word.startswith('@'):


### PR DESCRIPTION
- Hashtags should now all have the same shape, which is `str.lower()`, to be able to filter data correctly.  
Example: The two hashtags, `#Trump` & `#trump` will now be considered *the same*.

- Mentions now keep their shape, instead of `str.lower()`.  
Example: `@realDonaldTrump` stays `@realDonaldTrump` - before it was forced `@realdonaldtrump`.