### PR TITLE
[BUG] Fix relative links for saving tweets

### DIFF
--- a/modules/web_scraper.py
+++ b/modules/web_scraper.py
@@ -165,8 +165,8 @@ def get_tweets(tweet_count: int, fresh_search: bool, hashtags: list):
 
     # If we don't want to do a fresh search and if the file corresponding to the hashtag(s) exists then return the file content
     if not (fresh_search):
-        if os.path.isfile("../tweets/" + file_name):
-            with open("../tweets/" + file_name, 'r', encoding="utf-8") as f:
+        if os.path.isfile("./tweets/" + file_name):
+            with open("./tweets/" + file_name, 'r', encoding="utf-8") as f:
                 # The first line in each save file will contain a number which is the amount of tweets in the file
                 # If the user requests more tweets than what has previously been saved in the file then we have to do a fresh search
                 amount_of_tweets_in_file = int(f.readline())
@@ -217,7 +217,7 @@ def get_tweets(tweet_count: int, fresh_search: bool, hashtags: list):
             tweets.append(element)
     
     # Saving tweets in file
-    with open("../tweets/" + file_name, 'w', encoding="utf-8") as f:
+    with open("./tweets/" + file_name, 'w', encoding="utf-8") as f:
         f.write(str(loop_count*20) + "\n")
         for index, element in enumerate(tweets):
             f.write(str(element))

--- a/modules/web_scraper.py
+++ b/modules/web_scraper.py
@@ -163,7 +163,7 @@ def get_tweets(tweet_count: int, fresh_search: bool, hashtags: list):
     # Adding the end-part of the URL to URL after all search parameters have been added
     URL += _end_URL_part
     # Make tweet directory if not already there
-    Path("./plots").mkdir(parents=True, exist_ok=True)
+    Path("./tweets").mkdir(parents=True, exist_ok=True)
     # If we don't want to do a fresh search and if the file corresponding to the hashtag(s) exists then return the file content
     if not (fresh_search):
         with open("./tweets/" + file_name, 'r', encoding="utf-8") as f:

--- a/modules/web_scraper.py
+++ b/modules/web_scraper.py
@@ -1,5 +1,6 @@
 import bs4
 import requests as req
+import os
 from datetime import date, datetime
 import emoji
 import ast
@@ -166,19 +167,22 @@ def get_tweets(tweet_count: int, fresh_search: bool, hashtags: list):
     Path("./tweets").mkdir(parents=True, exist_ok=True)
     # If we don't want to do a fresh search and if the file corresponding to the hashtag(s) exists then return the file content
     if not (fresh_search):
-        with open("./tweets/" + file_name, 'r', encoding="utf-8") as f:
-            # The first line in each save file will contain a number which is the amount of tweets in the file
-            # If the user requests more tweets than what has previously been saved in the file then we have to do a fresh search
-            amount_of_tweets_in_file = int(f.readline())
-            if amount_of_tweets_in_file >= tweet_count:  
-                result = []
-                count = 0
-                for line in f.readlines():
-                    if count > tweet_count - 1:
-                        break
-                    result.append(ast.literal_eval(line))
-                    count += 1
-                return result
+        if os.path.isfile("./tweets/" + file_name):
+            with open("./tweets/" + file_name, 'r', encoding="utf-8") as f:
+                # The first line in each save file will contain a number which is the amount of tweets in the file
+                # If the user requests more tweets than what has previously been saved in the file then we have to do a fresh search
+                amount_of_tweets_in_file = int(f.readline())
+                if amount_of_tweets_in_file >= tweet_count:  
+                    result = []
+                    count = 0
+                    for line in f.readlines():
+                        if count > tweet_count - 1:
+                            break
+                        result.append(ast.literal_eval(line))
+                        count += 1
+                    return result
+        else:
+            print(f'Could not find file: {file_name}\nContinuing with fresh search...')
 
 
     # Result array with all the tweets

--- a/modules/web_scraper.py
+++ b/modules/web_scraper.py
@@ -1,9 +1,9 @@
 import bs4
 import requests as req
-import os
 from datetime import date, datetime
 import emoji
 import ast
+from pathlib import Path
 
 _base_URL = "https://mobile.twitter.com/search?q="
 _end_URL_part = "&s=typd&x=0&y=0"
@@ -162,23 +162,23 @@ def get_tweets(tweet_count: int, fresh_search: bool, hashtags: list):
             file_name += (hashtag + "_")
     # Adding the end-part of the URL to URL after all search parameters have been added
     URL += _end_URL_part
-
+    # Make tweet directory if not already there
+    Path("./plots").mkdir(parents=True, exist_ok=True)
     # If we don't want to do a fresh search and if the file corresponding to the hashtag(s) exists then return the file content
     if not (fresh_search):
-        if os.path.isfile("./tweets/" + file_name):
-            with open("./tweets/" + file_name, 'r', encoding="utf-8") as f:
-                # The first line in each save file will contain a number which is the amount of tweets in the file
-                # If the user requests more tweets than what has previously been saved in the file then we have to do a fresh search
-                amount_of_tweets_in_file = int(f.readline())
-                if amount_of_tweets_in_file >= tweet_count:  
-                    result = []
-                    count = 0
-                    for line in f.readlines():
-                        if count > tweet_count - 1:
-                            break
-                        result.append(ast.literal_eval(line))
-                        count += 1
-                    return result
+        with open("./tweets/" + file_name, 'r', encoding="utf-8") as f:
+            # The first line in each save file will contain a number which is the amount of tweets in the file
+            # If the user requests more tweets than what has previously been saved in the file then we have to do a fresh search
+            amount_of_tweets_in_file = int(f.readline())
+            if amount_of_tweets_in_file >= tweet_count:  
+                result = []
+                count = 0
+                for line in f.readlines():
+                    if count > tweet_count - 1:
+                        break
+                    result.append(ast.literal_eval(line))
+                    count += 1
+                return result
 
 
     # Result array with all the tweets


### PR DESCRIPTION
Simple fix. :) 

- [x] Works with app.py
- [x] Works with flask_service.py
- [x] Unrelated to bug, but `web_scraper.py` now creates the `tweets`-subfolder if it does not exist.
  - [x] yes it has been tested but I forgot to push the actual folder name change (did ctrl-z to remove some formatting changes, one too many)
  - [x] Prints if file was not found


Ok, so when I run `flask_service.py` on this branch it correctly saves to `PythonExam\plots` and `PythonExam\tweets`. I did not change anything in the plotting settings, so I am not sure why it ever saved plots to `PythonExam\Modules\plots`?
![image](https://user-images.githubusercontent.com/37186286/82041583-af6c3d80-96a8-11ea-8447-112393045b99.png)

It also works when using app.py, where it saves to `PythonExam\tweets`
![image](https://user-images.githubusercontent.com/37186286/82041833-1b4ea600-96a9-11ea-8f31-4391e938f0d2.png)
